### PR TITLE
Implement minimal-pixels option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023.10.18 zunda <zundan@gmail.com>
+	* qrenc.c:
+	  - Added --minimal-pixels option.
+
 2020.09.28 Kentaro Fukuchi <kentaro@fukuchi.org>
 	[hotfix]
 	* qrinput.c, tests/test_estimatebit.c:


### PR DESCRIPTION
Which makes less important pixels transparent.
This may make the result incompliant with the specifications.